### PR TITLE
Don't suppressWarnings

### DIFF
--- a/includes/MonacoTemplate.php
+++ b/includes/MonacoTemplate.php
@@ -1,7 +1,6 @@
 <?php
 
 use MediaWiki\MediaWikiServices;
-use Wikimedia\AtEase\AtEase;
 
 class MonacoTemplate extends BaseTemplate {
 	/**
@@ -36,9 +35,6 @@ class MonacoTemplate extends BaseTemplate {
 		$namespace = $wgTitle->getNamespace();
 
 		$this->set( 'blankimg', $this->data['stylepath'] . '/Monaco/style/images/blank.gif' );
-
-		// Suppress warnings to prevent notices about missing indexes in $this->data
-		AtEase::suppressWarnings();
 		
 		$this->setupRightSidebar();
 		ob_start();


### PR DESCRIPTION
The problem with warning suppression is it also suppresses deprecations which might make it harder for those to get addressed.
This was recently a problem in Pivot skin which broke with 1.38.