### PR TITLE
MonacoTemplate: Fix "Call to undefined method LanguageZh::getPreferredVariant()"

### DIFF
--- a/includes/MonacoTemplate.php
+++ b/includes/MonacoTemplate.php
@@ -1100,8 +1100,9 @@ if ( $user->isAnon() ) {
 		}
 		if ( isset( $this->data['articlelinks']['variants'] ) ) {
 			$contLang = MediaWikiServices::getInstance()->getContentLanguage();
-
-			$preferred = $contLang->getPreferredVariant();
+			$converter = MediaWikiServices::getInstance()->getLanguageConverterFactory()
+				->getLanguageConverter( $contLang );
+			$preferred = $converter->getPreferredVariant();
 			$bar[] = [
 				"id" => "page_variants",
 				"type" => "tabs",


### PR DESCRIPTION
```
from /srv/mediawiki/1.43/skins/Monaco/includes/MonacoTemplate.php(1104)
#0 /srv/mediawiki/1.43/skins/Monaco/includes/MonacoTemplate.php(1080): MonacoTemplate->realPrintPageBar()
#1 /srv/mediawiki/1.43/skins/Monaco/includes/MonacoTemplate.php(115): MonacoTemplate->printPageBar()
#2 /srv/mediawiki/1.43/includes/skins/SkinTemplate.php(161): MonacoTemplate->execute()
#3 /srv/mediawiki/1.43/includes/skins/SkinTemplate.php(180): SkinTemplate->generateHTML()
#4 /srv/mediawiki/1.43/includes/skins/Skin.php(683): SkinTemplate->outputPage()
#5 /srv/mediawiki/1.43/includes/Output/OutputPage.php(3193): Skin->outputPageFinal(MediaWiki\Output\OutputPage)
#6 /srv/mediawiki/1.43/includes/actions/ActionEntryPoint.php(163): MediaWiki\Output\OutputPage->output(bool)
#7 /srv/mediawiki/1.43/includes/MediaWikiEntryPoint.php(200): MediaWiki\Actions\ActionEntryPoint->execute()
#8 /srv/mediawiki/config/initialise/entrypoints/index.php(98): MediaWiki\MediaWikiEntryPoint->run()
#9 {main}
```