### PR TITLE
Fix 1.44 compatibility; replace deprecated methods

### DIFF
--- a/includes/MonacoSidebar.php
+++ b/includes/MonacoSidebar.php
@@ -1,7 +1,10 @@
 <?php
 
 use MediaWiki\HookContainer\HookContainer;
+use MediaWiki\Html\Html;
 use MediaWiki\MediaWikiServices;
+use MediaWiki\Title\Title;
+use MediaWiki\Utils\UrlUtils;
 
 class MonacoSidebar {
 	/** @var array */
@@ -69,7 +72,8 @@ class MonacoSidebar {
 			if ( !wfMessage( $line_temp[0] )->exists() ) {
 				$link = $line_temp[0];
 			}
-			if ( preg_match( '/^(?:' . wfUrlProtocols() . ')/', $link ) ) {
+			$urlUtils = MediaWikiServices::getInstance()->getUrlUtils();
+			if ( preg_match( '/^(?:' . $urlUtils->validProtocols() . ')/', $link ) ) {
 				$href = $link;
 			} else {
 				$title = Title::newFromText( $link );
@@ -480,7 +484,8 @@ class MonacoSidebar {
 			$link = $lineTmp[0];
 		}
 
-		if ( preg_match( '/^(?:' . wfUrlProtocols() . ')/', $link ) ) {
+		$urlUtils = MediaWikiServices::getInstance()->getUrlUtils();
+		if ( preg_match( '/^(?:' . $urlUtils->validProtocols() . ')/', $link ) ) {
 			$href = $link;
 		} else {
 			if ( empty( $link ) ) {

--- a/includes/MonacoTemplate.php
+++ b/includes/MonacoTemplate.php
@@ -1,8 +1,12 @@
 <?php
 
 use MediaWiki\Config\GlobalVarConfig;
+use MediaWiki\Html\Html;
+use MediaWiki\Linker\Linker;
 use MediaWiki\MediaWikiServices;
 use MediaWiki\HookContainer\HookContainer;
+use MediaWiki\Skin\SkinComponentUtils;
+use MediaWiki\Title\Title;
 
 class MonacoTemplate extends BaseTemplate {
 
@@ -280,8 +284,8 @@ if ( !empty( $custom_article_footer ) ) {
 		}
 
 		$feRandIcon = $this->blankimg( [ 'id' => 'fe_random_img', 'class' => 'sprite random', 'alt' => '' ] );
-		$feRandIcon = Html::rawElement( 'a', [ 'id' => 'fe_random_icon', 'href' => Skin::makeSpecialUrl( 'Randompage' ) ], $feRandIcon );
-		$feRandLink = Html::rawElement( 'a', [ 'id' => 'fe_random_link', 'href' => Skin::makeSpecialUrl( 'Randompage' ) ], wfMessage( 'viewrandompage' )->escaped() );
+		$feRandIcon = Html::rawElement( 'a', [ 'id' => 'fe_random_icon', 'href' => SkinComponentUtils::makeSpecialUrl( 'Randompage' ) ], $feRandIcon );
+		$feRandLink = Html::rawElement( 'a', [ 'id' => 'fe_random_link', 'href' => SkinComponentUtils::makeSpecialUrl( 'Randompage' ) ], wfMessage( 'viewrandompage' )->escaped() );
 
 		$html .= '<ul class="actions clearfix" id="articleFooterActions2">';
 		$html .= Html::rawElement( 'li', [ 'id' => 'fe_randompage' ],
@@ -785,7 +789,7 @@ echo $html;
 		$returnto = wfArrayToCGI( $a );
 
 		if ( !$user->isRegistered() ) {
-			$signUpHref = Skin::makeSpecialUrl( 'Userlogin', $returnto );
+			$signUpHref = SkinComponentUtils::makeSpecialUrl( 'Userlogin', $returnto );
 			$data['login'] = [
 				'text' => wfMessage( 'login' )->text(),
 				'href' => $signUpHref . '&type=login'

--- a/includes/SkinMonaco.php
+++ b/includes/SkinMonaco.php
@@ -2,6 +2,7 @@
 
 use MediaWiki\MediaWikiServices;
 use MediaWiki\Revision\SlotRecord;
+use MediaWiki\Title\Title;
 use MediaWiki\User\UserOptionsLookup;
 
 class SkinMonaco extends SkinTemplate {


### PR DESCRIPTION
- Add namespaced imports for `Html`, `Title` and `Linker` (the non-namespaced aliases are removed in 1.44)
- Replace wfUrlProtocols() (hard-deprecated since 1.43) with UrlUtils->validProtocols()
- Replace Skin::makeSpecialUrl (deprecated since 1.39) with SkinComponentUtils::makeSpecialUrl

